### PR TITLE
Add Mahesta PHP skeleton

### DIFF
--- a/mahesta/README.md
+++ b/mahesta/README.md
@@ -1,0 +1,43 @@
+# Mahesta
+
+This directory contains a lightweight PHP skeleton for the Mahesta e-commerce project. It now includes a minimal product management module.
+
+## Setup
+
+1. Create a MySQL database named `mahesta` and add tables:
+
+```sql
+CREATE TABLE admins (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+2. Insert an admin user:
+
+```sql
+INSERT INTO admins (username, password) VALUES ('admin', PASSWORD_HASH('secret', PASSWORD_DEFAULT));
+```
+
+3. Configure database access in `config.php`.
+
+4. Serve the `mahesta` directory with PHP's built-in server for testing:
+
+```bash
+php -S localhost:8000 -t mahesta
+```
+
+Then visit `http://localhost:8000/mahesta` in your browser.

--- a/mahesta/admin/index.php
+++ b/mahesta/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+require __DIR__ . '/../index.php';

--- a/mahesta/config.php
+++ b/mahesta/config.php
@@ -1,0 +1,12 @@
+<?php
+return [
+    'db' => [
+        'host' => 'localhost',
+        'dbname' => 'mahesta',
+        'user' => 'root',
+        'pass' => '',
+        'charset' => 'utf8mb4',
+    ],
+    'base_url' => '/mahesta',
+    'site_title' => 'Mahesta',
+];

--- a/mahesta/controllers/AdminController.php
+++ b/mahesta/controllers/AdminController.php
@@ -1,0 +1,45 @@
+<?php
+use Core\Auth;
+
+class AdminController
+{
+    public function login(): void
+    {
+        $error = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $username = trim($_POST['username'] ?? '');
+            $password = trim($_POST['password'] ?? '');
+            if (Auth::attempt($username, $password)) {
+                header('Location: ' . Auth::baseUrl('/admin'));
+                exit();
+            } else {
+                $error = 'Invalid credentials';
+            }
+        }
+        $title = 'Admin Login';
+        require __DIR__ . '/../templates/header.php';
+        require __DIR__ . '/../views/admin/login.php';
+        require __DIR__ . '/../templates/footer.php';
+    }
+
+    public function index(): void
+    {
+        Auth::requireLogin();
+        $pdo = Core\Database::connection();
+        $productCount = $pdo->query('SELECT COUNT(*) FROM products')->fetchColumn();
+        $title = 'Admin Dashboard';
+        require __DIR__ . '/../templates/header.php';
+        echo '<div class="container py-5">';
+        echo '<h1 class="mb-4">Admin Dashboard</h1>';
+        echo '<div class="alert alert-info">Total products: ' . $productCount . '</div>';
+        echo '</div>';
+        require __DIR__ . '/../templates/footer.php';
+    }
+
+    public function logout(): void
+    {
+        Auth::logout();
+        header('Location: ' . Auth::baseUrl('/admin/login'));
+        exit();
+    }
+}

--- a/mahesta/controllers/HomeController.php
+++ b/mahesta/controllers/HomeController.php
@@ -1,0 +1,14 @@
+<?php
+use Core\Auth;
+
+class HomeController
+{
+    public function index(): void
+    {
+        $products = Product::all();
+        $title = 'Welcome to Mahesta';
+        require __DIR__ . '/../templates/header.php';
+        require __DIR__ . '/../views/home.php';
+        require __DIR__ . '/../templates/footer.php';
+    }
+}

--- a/mahesta/controllers/ProductController.php
+++ b/mahesta/controllers/ProductController.php
@@ -1,0 +1,36 @@
+<?php
+use Core\Auth;
+
+class ProductController
+{
+    public function index(): void
+    {
+        Auth::requireLogin();
+        $products = Product::all();
+        $title = 'Products';
+        require __DIR__ . '/../templates/header.php';
+        require __DIR__ . '/../views/admin/products/index.php';
+        require __DIR__ . '/../templates/footer.php';
+    }
+
+    public function create(): void
+    {
+        Auth::requireLogin();
+        $error = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $titleField = trim($_POST['title'] ?? '');
+            $priceField = floatval($_POST['price'] ?? 0);
+            if ($titleField && $priceField) {
+                Product::create(['title' => $titleField, 'price' => $priceField]);
+                header('Location: ' . Auth::baseUrl('/admin/products'));
+                exit();
+            } else {
+                $error = 'Please fill all fields';
+            }
+        }
+        $title = 'Add Product';
+        require __DIR__ . '/../templates/header.php';
+        require __DIR__ . '/../views/admin/products/create.php';
+        require __DIR__ . '/../templates/footer.php';
+    }
+}

--- a/mahesta/core/Auth.php
+++ b/mahesta/core/Auth.php
@@ -1,0 +1,44 @@
+<?php
+namespace Core;
+
+class Auth
+{
+    public static function check(): bool
+    {
+        session_start();
+        return !empty($_SESSION['admin_id']);
+    }
+
+    public static function requireLogin(): void
+    {
+        if (!self::check()) {
+            header('Location: ' . self::baseUrl('/admin/login'));
+            exit();
+        }
+    }
+
+    public static function attempt(string $username, string $password): bool
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM admins WHERE username = ?');
+        $stmt->execute([$username]);
+        $admin = $stmt->fetch();
+        if ($admin && password_verify($password, $admin['password'])) {
+            $_SESSION['admin_id'] = $admin['id'];
+            return true;
+        }
+        return false;
+    }
+
+    public static function logout(): void
+    {
+        session_start();
+        session_destroy();
+    }
+
+    public static function baseUrl(string $path = ''): string
+    {
+        $config = require __DIR__ . '/../config.php';
+        return rtrim($config['base_url'], '/') . $path;
+    }
+}

--- a/mahesta/core/Database.php
+++ b/mahesta/core/Database.php
@@ -1,0 +1,22 @@
+<?php
+namespace Core;
+use PDO;
+
+class Database
+{
+    private static ?PDO $pdo = null;
+
+    public static function connection(): PDO
+    {
+        if (self::$pdo === null) {
+            $config = require __DIR__ . '/../config.php';
+            $db = $config['db'];
+            $dsn = sprintf('mysql:host=%s;dbname=%s;charset=%s', $db['host'], $db['dbname'], $db['charset']);
+            self::$pdo = new PDO($dsn, $db['user'], $db['pass'], [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        }
+        return self::$pdo;
+    }
+}

--- a/mahesta/index.php
+++ b/mahesta/index.php
@@ -1,0 +1,37 @@
+<?php
+require __DIR__ . '/core/Database.php';
+require __DIR__ . '/core/Auth.php';
+
+spl_autoload_register(function ($class) {
+    $paths = [__DIR__ . '/controllers', __DIR__ . '/models'];
+    foreach ($paths as $path) {
+        $file = $path . '/' . $class . '.php';
+        if (file_exists($file)) {
+            require $file;
+            return;
+        }
+    }
+});
+
+$uri = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+$base = trim((require __DIR__ . '/config.php')['base_url'], '/');
+if ($base && strpos($uri, $base) === 0) {
+    $uri = ltrim(substr($uri, strlen($base)), '/');
+}
+
+$routes = [
+    '' => [HomeController::class, 'index'],
+    'admin' => [AdminController::class, 'index'],
+    'admin/login' => [AdminController::class, 'login'],
+    'admin/logout' => [AdminController::class, 'logout'],
+    'admin/products' => [ProductController::class, 'index'],
+    'admin/products/create' => [ProductController::class, 'create'],
+];
+
+if (isset($routes[$uri])) {
+    [$controller, $method] = $routes[$uri];
+    (new $controller)->$method();
+} else {
+    http_response_code(404);
+    echo '404 Not Found';
+}

--- a/mahesta/models/Category.php
+++ b/mahesta/models/Category.php
@@ -1,0 +1,11 @@
+<?php
+use Core\Database;
+
+class Category
+{
+    public static function all(): array
+    {
+        $pdo = Database::connection();
+        return $pdo->query('SELECT * FROM categories ORDER BY id DESC')->fetchAll();
+    }
+}

--- a/mahesta/models/Product.php
+++ b/mahesta/models/Product.php
@@ -1,0 +1,20 @@
+<?php
+use Core\Database;
+
+class Product
+{
+    public static function all(): array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->query('SELECT * FROM products ORDER BY id DESC');
+        return $stmt->fetchAll();
+    }
+
+    public static function create(array $data): int
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('INSERT INTO products (title, price, created_at) VALUES (?, ?, NOW())');
+        $stmt->execute([$data['title'], $data['price']]);
+        return (int)$pdo->lastInsertId();
+    }
+}

--- a/mahesta/templates/footer.php
+++ b/mahesta/templates/footer.php
@@ -1,0 +1,8 @@
+<footer class="bg-light text-center py-4 mt-5">
+    <div class="container">
+        <p class="mb-0">&copy; <?php echo date('Y'); ?> Mahesta</p>
+    </div>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/mahesta/templates/header.php
+++ b/mahesta/templates/header.php
@@ -1,0 +1,19 @@
+<?php
+if (!isset($title)) {
+    $title = 'Mahesta';
+}
+?>
+<!DOCTYPE html>
+<html lang="en" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($title); ?></title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.rtl.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+        <a class="navbar-brand" href="<?php echo Core\Auth::baseUrl(); ?>">Mahesta</a>
+    </div>
+</nav>

--- a/mahesta/views/admin/login.php
+++ b/mahesta/views/admin/login.php
@@ -1,0 +1,17 @@
+<div class="container py-5" style="max-width:400px;">
+    <h2 class="mb-4">Admin Login</h2>
+    <?php if (!empty($error)): ?>
+    <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+</div>

--- a/mahesta/views/admin/products/create.php
+++ b/mahesta/views/admin/products/create.php
@@ -1,0 +1,17 @@
+<div class="container py-5" style="max-width:500px;">
+    <h2 class="mb-4">Add Product</h2>
+    <?php if (!empty($error)): ?>
+        <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" name="title" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Price</label>
+            <input type="number" step="0.01" name="price" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Save</button>
+    </form>
+</div>

--- a/mahesta/views/admin/products/index.php
+++ b/mahesta/views/admin/products/index.php
@@ -1,0 +1,28 @@
+<div class="container py-5">
+    <div class="d-flex justify-content-between mb-3">
+        <h2>Products</h2>
+        <a href="<?php echo Core\Auth::baseUrl('/admin/products/create'); ?>" class="btn btn-success">Add Product</a>
+    </div>
+    <?php if (empty($products)): ?>
+        <p>No products found.</p>
+    <?php else: ?>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Price</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($products as $product): ?>
+                    <tr>
+                        <td><?php echo $product['id']; ?></td>
+                        <td><?php echo htmlspecialchars($product['title']); ?></td>
+                        <td><?php echo $product['price']; ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</div>

--- a/mahesta/views/home.php
+++ b/mahesta/views/home.php
@@ -1,0 +1,16 @@
+<div class="container py-5">
+    <h1 class="mb-4">Mahesta Shop</h1>
+    <div class="row">
+        <?php foreach ($products as $product): ?>
+            <div class="col-md-4 mb-4">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title"><?php echo htmlspecialchars($product['title']); ?></h5>
+                        <p class="card-text"><?php echo $product['price']; ?> تومان</p>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <a href="<?php echo Core\Auth::baseUrl('/admin'); ?>" class="btn btn-primary mt-4">Admin Panel</a>
+</div>


### PR DESCRIPTION
## Summary
- start scaffolding a simple e-commerce project named **Mahesta**
- add DB config and basic MVC router
- implement minimal admin authentication helper and controller
- provide placeholder views with Bootstrap RTL
- add very basic product management

## Testing
- `php` was not available so syntax checks could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6845bce97bc4833383535a92aa63ed66