### PR TITLE
Enhance Mahesta UI

### DIFF
--- a/mahesta/assets/style.css
+++ b/mahesta/assets/style.css
@@ -1,0 +1,18 @@
+body {
+    background-color: #f8f9fa;
+}
+
+.hero {
+    background: linear-gradient(135deg, #4e73df, #1cc88a);
+    color: #fff;
+    padding: 80px 0;
+    text-align: center;
+}
+
+.hero h1 {
+    font-size: 3rem;
+}
+
+.card {
+    border-radius: 0.5rem;
+}

--- a/mahesta/controllers/AdminController.php
+++ b/mahesta/controllers/AdminController.php
@@ -29,10 +29,7 @@ class AdminController
         $productCount = $pdo->query('SELECT COUNT(*) FROM products')->fetchColumn();
         $title = 'Admin Dashboard';
         require __DIR__ . '/../templates/header.php';
-        echo '<div class="container py-5">';
-        echo '<h1 class="mb-4">Admin Dashboard</h1>';
-        echo '<div class="alert alert-info">Total products: ' . $productCount . '</div>';
-        echo '</div>';
+        require __DIR__ . '/../views/admin/dashboard.php';
         require __DIR__ . '/../templates/footer.php';
     }
 

--- a/mahesta/templates/header.php
+++ b/mahesta/templates/header.php
@@ -10,10 +10,33 @@ if (!isset($title)) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($title); ?></title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.rtl.min.css">
+    <link rel="stylesheet" href="<?php echo Core\Auth::baseUrl('/assets/style.css'); ?>">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
         <a class="navbar-brand" href="<?php echo Core\Auth::baseUrl(); ?>">Mahesta</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="<?php echo Core\Auth::baseUrl(); ?>">Home</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="<?php echo Core\Auth::baseUrl('/admin'); ?>">Admin</a>
+                </li>
+                <?php if (Core\Auth::check()): ?>
+                    <li class="nav-item">
+                        <a class="nav-link" href="<?php echo Core\Auth::baseUrl('/admin/logout'); ?>">Logout</a>
+                    </li>
+                <?php else: ?>
+                    <li class="nav-item">
+                        <a class="nav-link" href="<?php echo Core\Auth::baseUrl('/admin/login'); ?>">Login</a>
+                    </li>
+                <?php endif; ?>
+            </ul>
+        </div>
     </div>
 </nav>

--- a/mahesta/views/admin/dashboard.php
+++ b/mahesta/views/admin/dashboard.php
@@ -1,0 +1,14 @@
+<div class="container py-5">
+    <h1 class="mb-4">Admin Dashboard</h1>
+    <div class="row">
+        <div class="col-md-4">
+            <div class="card text-center shadow-sm mb-3">
+                <div class="card-body">
+                    <h5 class="card-title">Products</h5>
+                    <p class="card-text display-6"><?php echo $productCount; ?></p>
+                    <a href="<?php echo Core\Auth::baseUrl('/admin/products'); ?>" class="btn btn-primary">Manage</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/mahesta/views/admin/login.php
+++ b/mahesta/views/admin/login.php
@@ -1,17 +1,21 @@
 <div class="container py-5" style="max-width:400px;">
-    <h2 class="mb-4">Admin Login</h2>
-    <?php if (!empty($error)): ?>
-    <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
-    <?php endif; ?>
-    <form method="post">
-        <div class="mb-3">
-            <label class="form-label">Username</label>
-            <input type="text" name="username" class="form-control" required>
+    <div class="card shadow-sm">
+        <div class="card-body p-4">
+            <h2 class="mb-4 text-center">Admin Login</h2>
+            <?php if (!empty($error)): ?>
+                <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+            <?php endif; ?>
+            <form method="post">
+                <div class="mb-3">
+                    <label class="form-label">Username</label>
+                    <input type="text" name="username" class="form-control" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Password</label>
+                    <input type="password" name="password" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Login</button>
+            </form>
         </div>
-        <div class="mb-3">
-            <label class="form-label">Password</label>
-            <input type="password" name="password" class="form-control" required>
-        </div>
-        <button type="submit" class="btn btn-primary w-100">Login</button>
-    </form>
+    </div>
 </div>

--- a/mahesta/views/admin/products/create.php
+++ b/mahesta/views/admin/products/create.php
@@ -1,17 +1,21 @@
 <div class="container py-5" style="max-width:500px;">
-    <h2 class="mb-4">Add Product</h2>
-    <?php if (!empty($error)): ?>
-        <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
-    <?php endif; ?>
-    <form method="post">
-        <div class="mb-3">
-            <label class="form-label">Title</label>
-            <input type="text" name="title" class="form-control" required>
+    <div class="card shadow-sm">
+        <div class="card-body p-4">
+            <h2 class="mb-4">Add Product</h2>
+            <?php if (!empty($error)): ?>
+                <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+            <?php endif; ?>
+            <form method="post">
+                <div class="mb-3">
+                    <label class="form-label">Title</label>
+                    <input type="text" name="title" class="form-control" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Price</label>
+                    <input type="number" step="0.01" name="price" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Save</button>
+            </form>
         </div>
-        <div class="mb-3">
-            <label class="form-label">Price</label>
-            <input type="number" step="0.01" name="price" class="form-control" required>
-        </div>
-        <button type="submit" class="btn btn-primary w-100">Save</button>
-    </form>
+    </div>
 </div>

--- a/mahesta/views/admin/products/index.php
+++ b/mahesta/views/admin/products/index.php
@@ -3,26 +3,32 @@
         <h2>Products</h2>
         <a href="<?php echo Core\Auth::baseUrl('/admin/products/create'); ?>" class="btn btn-success">Add Product</a>
     </div>
-    <?php if (empty($products)): ?>
-        <p>No products found.</p>
-    <?php else: ?>
-        <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th>ID</th>
-                    <th>Title</th>
-                    <th>Price</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($products as $product): ?>
-                    <tr>
-                        <td><?php echo $product['id']; ?></td>
-                        <td><?php echo htmlspecialchars($product['title']); ?></td>
-                        <td><?php echo $product['price']; ?></td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <?php if (empty($products)): ?>
+                <p class="mb-0">No products found.</p>
+            <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table table-bordered align-middle mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>ID</th>
+                                <th>Title</th>
+                                <th>Price</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($products as $product): ?>
+                                <tr>
+                                    <td><?php echo $product['id']; ?></td>
+                                    <td><?php echo htmlspecialchars($product['title']); ?></td>
+                                    <td><?php echo $product['price']; ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
 </div>

--- a/mahesta/views/home.php
+++ b/mahesta/views/home.php
@@ -1,16 +1,21 @@
-<div class="container py-5">
-    <h1 class="mb-4">Mahesta Shop</h1>
+<div class="hero mb-5">
+    <div class="container">
+        <h1 class="display-4 mb-3">Mahesta Shop</h1>
+        <p class="lead">Explore our latest products</p>
+        <a href="<?php echo Core\Auth::baseUrl('/admin'); ?>" class="btn btn-light">Admin Panel</a>
+    </div>
+</div>
+<div class="container pb-5">
     <div class="row">
         <?php foreach ($products as $product): ?>
             <div class="col-md-4 mb-4">
-                <div class="card h-100">
+                <div class="card h-100 shadow-sm">
                     <div class="card-body">
                         <h5 class="card-title"><?php echo htmlspecialchars($product['title']); ?></h5>
-                        <p class="card-text"><?php echo $product['price']; ?> تومان</p>
+                        <p class="card-text mb-0"><?php echo $product['price']; ?> تومان</p>
                     </div>
                 </div>
             </div>
         <?php endforeach; ?>
     </div>
-    <a href="<?php echo Core\Auth::baseUrl('/admin'); ?>" class="btn btn-primary mt-4">Admin Panel</a>
 </div>


### PR DESCRIPTION
## Summary
- add a simple stylesheet for the Mahesta module
- improve navigation bar with login/logout links
- redesign home page with a hero section
- polish admin login and product pages using cards
- create a basic admin dashboard view

## Testing
- `php -l mahesta/controllers/AdminController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca2ca3e48333876cfd75cc788b8a